### PR TITLE
Changed Password parameter type to Security.SecureString for better security

### DIFF
--- a/Scripts/ServiceFabricRPHelpers/ServiceFabricRPHelpers.psm1
+++ b/Scripts/ServiceFabricRPHelpers/ServiceFabricRPHelpers.psm1
@@ -353,7 +353,7 @@ param(
   [string] $CertificateName,
    
   [Parameter(Mandatory=$true)]
-  [string] $Password,   
+  [Security.SecureString] $Password,   
 
   [Parameter(Mandatory=$true, ParameterSetName="CreateNewCertificate")]
   [switch] $CreateSelfSignedCertificate,


### PR DESCRIPTION
It is a good practice to not provide value to Password parameter so that it is not in the Powershell history. Unfortunately, when the parameter is of type String, the value typed by the user is visible when Powershell asks the user to supply a value for the parameter. When the type is SecureString, Powershell hides the value behind asterisks.
