### PR TITLE
Update ServiceFabricRPHelpers.psm1 [-Provider parameter no longer valid for powershell v5+?]

### DIFF
--- a/Scripts/ServiceFabricRPHelpers/ServiceFabricRPHelpers.psm1
+++ b/Scripts/ServiceFabricRPHelpers/ServiceFabricRPHelpers.psm1
@@ -413,7 +413,7 @@ if($CreateSelfSignedCertificate)
         New-SelfsignedCertificateEx -Subject "CN=$DnsName" -EKU "Server Authentication", "Client authentication" -KeyUsage "KeyEncipherment, DigitalSignature" -Path $NewPfxFilePath -Password $securePassword -Exportable
     }
     else {
-        New-SelfSignedCertificate -CertStoreLocation Cert:\CurrentUser\My -DnsName $DnsName -Provider 'Microsoft Enhanced Cryptographic Provider v1.0' | Export-PfxCertificate -FilePath $NewPfxFilePath -Password $securePassword | Out-Null
+        New-SelfSignedCertificate -CertStoreLocation Cert:\CurrentUser\My -DnsName $DnsName | Export-PfxCertificate -FilePath $NewPfxFilePath -Password $securePassword | Out-Null
     }
 
     $ExistingPfxFilePath = $NewPfxFilePath


### PR DESCRIPTION
The "New-SelfSignedCertificate" in the else block no longer works with powershell v5 (and higher?):

    $PspkiVersion = (Get-Module PSPKI).Version
    if($PSPKIVersion.Major -ieq 3 -And $PspkiVersion.Minor -ieq 2 -And $PspkiVersion.Build -ieq 5) {
        New-SelfsignedCertificateEx -Subject "CN=$DnsName" -EKU "Server Authentication", "Client authentication" -KeyUsage "KeyEncipherment, DigitalSignature" -Path $NewPfxFilePath -Password $securePassword -Exportable
    }
    else {
        New-SelfSignedCertificate -CertStoreLocation Cert:\CurrentUser\My -DnsName $DnsName -Provider 'Microsoft Enhanced Cryptographic Provider v1.0' | Export-PfxCertificate -FilePath $NewPfxFilePath -Password $securePassword | Out-Null
    }

We got it to work by removing "-Provider 'Microsoft Enhanced Cryptographic Provider v1.0'" from the New-SelfSignedCertificate line.