### PR TITLE
Clientcertificates voor management UI

### DIFF
--- a/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_RollOverStep1.json
+++ b/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_RollOverStep1.json
@@ -199,7 +199,7 @@
     "virtualNetworkName": "VNet",
     "addressPrefix": "10.0.0.0/16",
     "nicName": "NIC",
-    "lbIPName": "PublicIP-LB-FE",
+    "lbIPName": "[concat('PublicIP-LB-FE-', parameters('clusterName'))]", 
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "overProvision": "false",
     "vmssApiVersion": "2016-03-30",
@@ -696,7 +696,12 @@
           "x509StoreName": "[parameters('sfReverseProxyCertificateStoreValue')]"
         },
         "clientCertificateCommonNames": [],
-        "clientCertificateThumbprints": [],
+        "clientCertificateThumbprints": [
+          {
+            "CertificateThumbprint": "[parameters('clusterCertificateThumbprint')]",
+            "IsAdmin": true
+          }
+        ],
         "clusterState": "Default",
         "diagnosticsStorageAccountConfig": {
           "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.blob]",

--- a/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_RollOverStep2.json
+++ b/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_RollOverStep2.json
@@ -199,7 +199,7 @@
     "virtualNetworkName": "VNet",
     "addressPrefix": "10.0.0.0/16",
     "nicName": "NIC",
-    "lbIPName": "PublicIP-LB-FE",
+    "lbIPName": "[concat('PublicIP-LB-FE-', parameters('clusterName'))]", 
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "overProvision": "false",
     "vmssApiVersion": "2016-03-30",
@@ -697,7 +697,12 @@
           "x509StoreName": "[parameters('sfReverseProxyCertificateStoreValue')]"
         },
         "clientCertificateCommonNames": [],
-        "clientCertificateThumbprints": [],
+        "clientCertificateThumbprints": [
+          {
+            "CertificateThumbprint": "[parameters('clusterCertificateThumbprint')]",
+            "IsAdmin": true
+          }
+        ],
         "clusterState": "Default",
         "diagnosticsStorageAccountConfig": {
           "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.blob]",

--- a/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_Step1.json
+++ b/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_Step1.json
@@ -154,7 +154,7 @@
     "virtualNetworkName": "VNet",
     "addressPrefix": "10.0.0.0/16",
     "nicName": "NIC",
-    "lbIPName": "PublicIP-LB-FE",
+    "lbIPName": "[concat('PublicIP-LB-FE-', parameters('clusterName'))]", 
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "overProvision": "false",
     "vmssApiVersion": "2016-03-30",
@@ -603,7 +603,12 @@
           "x509StoreName": "[parameters('clusterCertificateStoreValue')]"
         },
         "clientCertificateCommonNames": [],
-        "clientCertificateThumbprints": [],
+        "clientCertificateThumbprints": [
+          {
+            "CertificateThumbprint": "[parameters('clusterCertificateThumbprint')]",
+            "IsAdmin": true
+          }
+        ],
         "clusterState": "Default",
         "diagnosticsStorageAccountConfig": {
           "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.blob]",

--- a/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_Step2.json
+++ b/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_Step2.json
@@ -180,7 +180,7 @@
     "virtualNetworkName": "VNet",
     "addressPrefix": "10.0.0.0/16",
     "nicName": "NIC",
-    "lbIPName": "PublicIP-LB-FE",
+    "lbIPName": "[concat('PublicIP-LB-FE-', parameters('clusterName'))]", 
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "overProvision": "false",
     "vmssApiVersion": "2016-03-30",
@@ -637,7 +637,12 @@
           "x509StoreName": "[parameters('clusterCertificateStoreValue')]"
         },
         "clientCertificateCommonNames": [],
-        "clientCertificateThumbprints": [],
+        "clientCertificateThumbprints": [
+          {
+            "CertificateThumbprint": "[parameters('clusterCertificateThumbprint')]",
+            "IsAdmin": true
+          }
+        ],
         "clusterState": "Default",
         "diagnosticsStorageAccountConfig": {
           "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.blob]",

--- a/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_Step3.json
+++ b/ARM Templates/ReverseProxySecureSample/5-VM-1-NodeTypes-SecureRP_Step3.json
@@ -186,7 +186,7 @@
     "virtualNetworkName": "VNet",
     "addressPrefix": "10.0.0.0/16",
     "nicName": "NIC",
-    "lbIPName": "PublicIP-LB-FE",
+    "lbIPName": "[concat('PublicIP-LB-FE-', parameters('clusterName'))]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "overProvision": "false",
     "vmssApiVersion": "2016-04-30-preview",
@@ -675,7 +675,12 @@
           "x509StoreName": "[parameters('sfReverseProxyCertificateStoreValue')]"
         },
         "clientCertificateCommonNames": [],
-        "clientCertificateThumbprints": [],
+        "clientCertificateThumbprints": [
+          {
+            "CertificateThumbprint": "[parameters('clusterCertificateThumbprint')]",
+            "IsAdmin": true
+          }
+        ],
         "clusterState": "Default",
         "diagnosticsStorageAccountConfig": {
           "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), variables('storageApiVersion')).primaryEndpoints.blob]",


### PR DESCRIPTION
Without the clientcertificates if you try to enter the management UI of SF you get a 403. It seems to be that when you set up a secured cluster node, a client certificate is also required to login in the admin UI