### PR TITLE
Removed sha256 flag

### DIFF
--- a/Scripts/CertUpload4Linux/CreateAndUploadtoKeyvault.md
+++ b/Scripts/CertUpload4Linux/CreateAndUploadtoKeyvault.md
@@ -32,7 +32,7 @@ There are three pieces of information you will need to provide in your template 
 
 Certificate Thumbprint:
 ```
-CERT_THUMB=$(openssl x509 -in server.crt -noout -sha256 -fingerprint | awk -F= '{print $NF}' | sed -e 's/://g')
+CERT_THUMB=$(openssl x509 -in server.crt -noout -fingerprint | awk -F= '{print $NF}' | sed -e 's/://g')
 ```
 
 Secret's URL:


### PR DESCRIPTION
As Raghu K Nair points out (https://stackoverflow.com/a/41840946/498238) the sha256 flag mentioned in the documentation generates incorrect thumbprints.

Kudos go to him.